### PR TITLE
fix: accept ParentNodes in waitForSelector

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,17 +11,17 @@ export function waitForFrame(): Promise<void> {
 }
 
 export function waitForSelector<K extends keyof HTMLElementTagNameMap>(
-  node: HTMLElement,
+  node: ParentNode,
   selector: K,
   attempts?: number
 ): Promise<HTMLElementTagNameMap[K]>;
 export function waitForSelector<K extends keyof SVGElementTagNameMap>(
-  node: HTMLElement,
+  node: ParentNode,
   selector: K,
   attempts?: number
 ): Promise<SVGElementTagNameMap[K]>;
 export function waitForSelector(
-  node: HTMLElement,
+  node: ParentNode,
   selector: string,
   attempts?: number
 ): Promise<Element>;
@@ -33,7 +33,7 @@ export function waitForSelector(
  * @return {Promise}
  */
 export function waitForSelector(
-  node: HTMLElement,
+  node: ParentNode,
   selector: string,
   attempts: number = 20
 ): Promise<Element> {

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -52,6 +52,31 @@ suite('waitForSelector', () => {
 
     assert.is(result, pTag);
   });
+
+  test('resolves when selector exists in shadow root', async () => {
+    const node = document.createElement('div');
+    const shadow = node.attachShadow({mode: 'open'});
+    const pTag = document.createElement('p');
+    shadow.appendChild(pTag);
+
+    const result = await lib.waitForSelector(shadow, 'p');
+
+    assert.is(result, pTag);
+  });
+
+  test('resolves when selector exists in document', async () => {
+    const node = document.createElement('div');
+
+    try {
+      document.body.appendChild(node);
+
+      const result = await lib.waitForSelector(document, 'div');
+
+      assert.is(result, node);
+    } finally {
+      node.remove();
+    }
+  });
 });
 
 suite('waitForFrame', () => {


### PR DESCRIPTION
things like shadow roots, documents, etc are not `HTMLElement` but do have `querySelector`. so we should accept a `ParentNode` rather than a `HTMLElement`.